### PR TITLE
Remove redundant concat for mod comments

### DIFF
--- a/include/cleanup/anonymous_update.php
+++ b/include/cleanup/anonymous_update.php
@@ -64,7 +64,7 @@ function docleanup($data)
         $count = count($users_buffer);
         if ($count > 0) {
             sql_query("INSERT INTO messages (sender,receiver,added,msg,subject) VALUES " . implode(', ', $msgs_buffer)) or sqlerr(__FILE__, __LINE__);
-            sql_query("INSERT INTO users (id, anonymous_until, anonymous, modcomment) VALUES " . implode(', ', $users_buffer) . " ON DUPLICATE key UPDATE anonymous_until=values(anonymous_until),anonymous=values(anonymous), modcomment=concat(values(modcomment),modcomment)") or sqlerr(__FILE__, __LINE__);
+            sql_query("INSERT INTO users (id, anonymous_until, anonymous, modcomment) VALUES " . implode(', ', $users_buffer) . " ON DUPLICATE key UPDATE anonymous_until=values(anonymous_until),anonymous=values(anonymous), modcomment=values(modcomment)") or sqlerr(__FILE__, __LINE__);
             write_log("Cleanup - Removed Anonymous profile from " . $count . " members");
         }
         unset($users_buffer, $msgs_buffer, $count);

--- a/include/cleanup/autoinvite_update.php
+++ b/include/cleanup/autoinvite_update.php
@@ -66,7 +66,7 @@ function docleanup($data)
         $count = count($users_buffer);
         if ($count > 0) {
             sql_query("INSERT INTO messages (sender,receiver,added,msg,subject) VALUES " . implode(', ', $msgs_buffer)) or sqlerr(__FILE__, __LINE__);
-            sql_query("INSERT INTO users (id, invites, modcomment) VALUES " . implode(', ', $users_buffer) . " ON DUPLICATE key UPDATE invites = invites+values(invites), modcomment=concat(values(modcomment),modcomment)") or sqlerr(__FILE__, __LINE__);
+            sql_query("INSERT INTO users (id, invites, modcomment) VALUES " . implode(', ', $users_buffer) . " ON DUPLICATE key UPDATE invites = invites+values(invites), modcomment=values(modcomment)") or sqlerr(__FILE__, __LINE__);
             write_log("Cleanup: Awarded 2 bonus invites to " . $count . " member(s) ");
         }
         unset($users_buffer, $msgs_buffer, $update, $count);

--- a/include/cleanup/avatarpos_update.php
+++ b/include/cleanup/avatarpos_update.php
@@ -54,7 +54,7 @@ function docleanup($data)
         $count = count($users_buffer);
         if ($count > 0) {
             sql_query("INSERT INTO messages (sender,receiver,added,msg,subject) VALUES " . implode(', ', $msgs_buffer)) or sqlerr(__FILE__, __LINE__);
-            sql_query("INSERT INTO users (id, avatarpos, modcomment) VALUES " . implode(', ', $users_buffer) . " ON DUPLICATE key UPDATE avatarpos=values(avatarpos), modcomment=concat(values(modcomment),modcomment)") or sqlerr(__FILE__, __LINE__);
+            sql_query("INSERT INTO users (id, avatarpos, modcomment) VALUES " . implode(', ', $users_buffer) . " ON DUPLICATE key UPDATE avatarpos=values(avatarpos), modcomment=values(modcomment)") or sqlerr(__FILE__, __LINE__);
             write_log("Cleanup - Removed Avatar ban from " . $count . " members");
         }
         unset($users_buffer, $msgs_buffer, $count);

--- a/include/cleanup/chatpost_update.php
+++ b/include/cleanup/chatpost_update.php
@@ -54,7 +54,7 @@ function docleanup($data)
         $count = count($users_buffer);
         if ($count > 0) {
             sql_query("INSERT INTO messages (sender,receiver,added,msg,subject) VALUES " . implode(', ', $msgs_buffer)) or sqlerr(__FILE__, __LINE__);
-            sql_query("INSERT INTO users (id, chatpost, modcomment) VALUES " . implode(', ', $users_buffer) . " ON DUPLICATE key UPDATE chatpost=values(chatpost), modcomment=concat(values(modcomment),modcomment)") or sqlerr(__FILE__, __LINE__);
+            sql_query("INSERT INTO users (id, chatpost, modcomment) VALUES " . implode(', ', $users_buffer) . " ON DUPLICATE key UPDATE chatpost=values(chatpost), modcomment=values(modcomment)") or sqlerr(__FILE__, __LINE__);
             write_log("Cleanup - Removed Chatpost ban from " . $count . " members");
         }
         unset($users_buffer, $msgs_buffer, $count);

--- a/include/cleanup/customsmilie_update.php
+++ b/include/cleanup/customsmilie_update.php
@@ -62,7 +62,7 @@ function docleanup($data)
         $count = count($users_buffer);
         if ($count > 0) {
             sql_query("INSERT INTO messages (sender,receiver,added,msg,subject) VALUES " . implode(', ', $msgs_buffer)) or sqlerr(__FILE__, __LINE__);
-            sql_query("INSERT INTO users (id, smile_until, modcomment) VALUES " . implode(', ', $users_buffer) . " ON DUPLICATE key UPDATE smile_until=values(smile_until),modcomment=concat(values(modcomment),modcomment)") or sqlerr(__FILE__, __LINE__);
+            sql_query("INSERT INTO users (id, smile_until, modcomment) VALUES " . implode(', ', $users_buffer) . " ON DUPLICATE key UPDATE smile_until=values(smile_until),modcomment=values(modcomment)") or sqlerr(__FILE__, __LINE__);
             write_log("Cleanup - Removed Custom smilies from " . $count . " members");
         }
         unset($users_buffer, $msgs_buffer, $count);

--- a/include/cleanup/downloadpos_update.php
+++ b/include/cleanup/downloadpos_update.php
@@ -54,7 +54,7 @@ function docleanup($data)
         $count = count($users_buffer);
         if ($count > 0) {
             sql_query("INSERT INTO messages (sender,receiver,added,msg,subject) VALUES " . implode(', ', $msgs_buffer)) or sqlerr(__FILE__, __LINE__);
-            sql_query("INSERT INTO users (id, downloadpos, modcomment) VALUES " . implode(', ', $users_buffer) . " ON DUPLICATE key UPDATE downloadpos=values(downloadpos), modcomment=concat(values(modcomment),modcomment)") or sqlerr(__FILE__, __LINE__);
+            sql_query("INSERT INTO users (id, downloadpos, modcomment) VALUES " . implode(', ', $users_buffer) . " ON DUPLICATE key UPDATE downloadpos=values(downloadpos), modcomment=values(modcomment)") or sqlerr(__FILE__, __LINE__);
             write_log("Cleanup - Removed Download ban from " . $count . " members");
         }
         unset($users_buffer, $msgs_buffer, $count);

--- a/include/cleanup/freeuser_update.php
+++ b/include/cleanup/freeuser_update.php
@@ -54,7 +54,7 @@ function docleanup($data)
         $count = count($users_buffer);
         if ($count > 0) {
             sql_query("INSERT INTO messages (sender,receiver,added,msg,subject) VALUES " . implode(', ', $msgs_buffer)) or sqlerr(__FILE__, __LINE__);
-            sql_query("INSERT INTO users (id, free_switch, modcomment) VALUES " . implode(', ', $users_buffer) . " ON DUPLICATE key UPDATE free_switch=values(free_switch), modcomment=concat(values(modcomment),modcomment)") or sqlerr(__FILE__, __LINE__);
+            sql_query("INSERT INTO users (id, free_switch, modcomment) VALUES " . implode(', ', $users_buffer) . " ON DUPLICATE key UPDATE free_switch=values(free_switch), modcomment=values(modcomment)") or sqlerr(__FILE__, __LINE__);
             write_log("Cleanup - Removed Freeleech from " . $count . " members");
         }
         unset($users_buffer, $msgs_buffer, $count);

--- a/include/cleanup/funds_update.php
+++ b/include/cleanup/funds_update.php
@@ -75,7 +75,7 @@ function docleanup($data)
         if ($count > 0) {
             sql_query("INSERT INTO messages (sender,receiver,added,msg,subject) VALUES " . implode(', ', $msgs_buffer)) or sqlerr(__FILE__, __LINE__);
             sql_query("INSERT INTO users (id, class, donor, donoruntil, modcomment) VALUES " . implode(', ', $users_buffer) . " ON DUPLICATE key UPDATE class=values(class),
-            donor=values(donor),donoruntil=values(donoruntil),modcomment=concat(values(modcomment),modcomment)") or sqlerr(__FILE__, __LINE__);
+            donor=values(donor),donoruntil=values(donoruntil),modcomment=values(modcomment)") or sqlerr(__FILE__, __LINE__);
             write_log("Cleanup: Donation status expired - " . $count . " Member(s)");
         }
         unset($users_buffer, $msgs_buffer, $update, $count);

--- a/include/cleanup/gameaccess_update.php
+++ b/include/cleanup/gameaccess_update.php
@@ -54,7 +54,7 @@ function docleanup($data)
         $count = count($users_buffer);
         if ($count > 0) {
             sql_query("INSERT INTO messages (sender,receiver,added,msg,subject) VALUES " . implode(', ', $msgs_buffer)) or sqlerr(__FILE__, __LINE__);
-            sql_query("INSERT INTO users (id, game_access, modcomment) VALUES " . implode(', ', $users_buffer) . " ON DUPLICATE key UPDATE game_access=values(game_access), modcomment=concat(values(modcomment),modcomment)") or sqlerr(__FILE__, __LINE__);
+            sql_query("INSERT INTO users (id, game_access, modcomment) VALUES " . implode(', ', $users_buffer) . " ON DUPLICATE key UPDATE game_access=values(game_access), modcomment=values(modcomment)") or sqlerr(__FILE__, __LINE__);
             write_log("Cleanup - Removed Game ban from " . $count . " members");
         }
         unset($users_buffer, $msgs_buffer, $count);

--- a/include/cleanup/immunity_update.php
+++ b/include/cleanup/immunity_update.php
@@ -54,7 +54,7 @@ function docleanup($data)
         $count = count($users_buffer);
         if ($count > 0) {
             sql_query("INSERT INTO messages (sender,receiver,added,msg,subject) VALUES " . implode(', ', $msgs_buffer)) or sqlerr(__FILE__, __LINE__);
-            sql_query("INSERT INTO users (id, immunity, modcomment) VALUES " . implode(', ', $users_buffer) . " ON DUPLICATE key UPDATE immunity=values(immunity), modcomment=concat(values(modcomment),modcomment)") or sqlerr(__FILE__, __LINE__);
+            sql_query("INSERT INTO users (id, immunity, modcomment) VALUES " . implode(', ', $users_buffer) . " ON DUPLICATE key UPDATE immunity=values(immunity), modcomment=values(modcomment)") or sqlerr(__FILE__, __LINE__);
             write_log("Cleanup - Removed Immunity from " . $count . " members");
         }
         unset($users_buffer, $msgs_buffer, $count);

--- a/include/cleanup/karmavip_update.php
+++ b/include/cleanup/karmavip_update.php
@@ -66,7 +66,7 @@ function docleanup($data)
         $count = count($users_buffer);
         if ($count > 0) {
             sql_query("INSERT INTO messages (sender,receiver,added,msg,subject) VALUES " . implode(', ', $msgs_buffer)) or sqlerr(__FILE__, __LINE__);
-            sql_query("INSERT INTO users (id, class, vip_added, vip_until, modcomment) VALUES " . implode(', ', $users_buffer) . " ON DUPLICATE key UPDATE class=values(class),vip_added=values(vip_added),vip_until=values(vip_until),modcomment=concat(values(modcomment),modcomment)") or sqlerr(__FILE__, __LINE__);
+            sql_query("INSERT INTO users (id, class, vip_added, vip_until, modcomment) VALUES " . implode(', ', $users_buffer) . " ON DUPLICATE key UPDATE class=values(class),vip_added=values(vip_added),vip_until=values(vip_until),modcomment=values(modcomment)") or sqlerr(__FILE__, __LINE__);
             write_log("Cleanup - Karma Vip status expired on - " . $count . " Member(s)");
         }
         unset($users_buffer, $msgs_buffer, $count);

--- a/include/cleanup/king_update.php
+++ b/include/cleanup/king_update.php
@@ -54,7 +54,7 @@ function docleanup($data)
         $count = count($users_buffer);
         if ($count > 0) {
             sql_query("INSERT INTO messages (sender,receiver,added,msg,subject) VALUES " . implode(', ', $msgs_buffer)) or sqlerr(__FILE__, __LINE__);
-            sql_query("INSERT INTO users (id, king, modcomment) VALUES " . implode(', ', $users_buffer) . " ON DUPLICATE key UPDATE king=values(king), modcomment=concat(values(modcomment),modcomment)") or sqlerr(__FILE__, __LINE__);
+            sql_query("INSERT INTO users (id, king, modcomment) VALUES " . implode(', ', $users_buffer) . " ON DUPLICATE key UPDATE king=values(king), modcomment=values(modcomment)") or sqlerr(__FILE__, __LINE__);
             write_log("Cleanup - Removed King status from " . $count . " members");
         }
         unset($users_buffer, $msgs_buffer, $count);

--- a/include/cleanup/leechwarn_update.php
+++ b/include/cleanup/leechwarn_update.php
@@ -72,7 +72,7 @@ function docleanup($data)
         $count = count($users_buffer);
         if ($count > 0) {
             sql_query("INSERT INTO messages (sender,receiver,added,msg,subject) VALUES " . implode(', ', $msgs_buffer)) or sqlerr(__FILE__, __LINE__);
-            sql_query("INSERT INTO users (id, leechwarn, downloadpos, modcomment) VALUES " . implode(', ', $users_buffer) . " ON DUPLICATE key UPDATE leechwarn=values(leechwarn),downloadpos=values(downloadpos),modcomment=concat(values(modcomment),modcomment)") or sqlerr(__FILE__, __LINE__);
+            sql_query("INSERT INTO users (id, leechwarn, downloadpos, modcomment) VALUES " . implode(', ', $users_buffer) . " ON DUPLICATE key UPDATE leechwarn=values(leechwarn),downloadpos=values(downloadpos),modcomment=values(modcomment)") or sqlerr(__FILE__, __LINE__);
             write_log("Cleanup: System applied auto leech Warning(s) to  " . $count . " Member(s)");
         }
         unset($users_buffer, $msgs_buffer, $update, $count);
@@ -115,7 +115,7 @@ function docleanup($data)
         $count = count($users_buffer);
         if ($count > 0) {
             sql_query("INSERT INTO messages (sender,receiver,added,msg,subject) VALUES " . implode(', ', $msgs_buffer)) or sqlerr(__FILE__, __LINE__);
-            sql_query("INSERT INTO users (id, leechwarn, downloadpos, modcomment) VALUES " . implode(', ', $users_buffer) . " ON DUPLICATE key UPDATE leechwarn=values(leechwarn),downloadpos=values(downloadpos),modcomment=concat(values(modcomment),modcomment)") or sqlerr(__FILE__, __LINE__);
+            sql_query("INSERT INTO users (id, leechwarn, downloadpos, modcomment) VALUES " . implode(', ', $users_buffer) . " ON DUPLICATE key UPDATE leechwarn=values(leechwarn),downloadpos=values(downloadpos),modcomment=values(modcomment)") or sqlerr(__FILE__, __LINE__);
             write_log("Cleanup: System removed auto leech Warning(s) and renabled download(s) - " . $count . " Member(s)");
         }
         unset($users_buffer, $msgs_buffer, $count);
@@ -151,7 +151,7 @@ function docleanup($data)
         }
         $count = count($users_buffer);
         if ($count > 0) {
-            sql_query("INSERT INTO users (id, leechwarn, enabled, modcomment) VALUES " . implode(', ', $users_buffer) . " ON DUPLICATE key UPDATE class=values(class),leechwarn=values(leechwarn),enabled=values(enabled),modcomment=concat(values(modcomment),modcomment)") or sqlerr(__FILE__, __LINE__);
+            sql_query("INSERT INTO users (id, leechwarn, enabled, modcomment) VALUES " . implode(', ', $users_buffer) . " ON DUPLICATE key UPDATE class=values(class),leechwarn=values(leechwarn),enabled=values(enabled),modcomment=values(modcomment)") or sqlerr(__FILE__, __LINE__);
             write_log("Cleanup: Disabled " . $count . " Member(s) - Leechwarns expired");
         }
         unset($users_buffer, $count);

--- a/include/cleanup/pirate_update.php
+++ b/include/cleanup/pirate_update.php
@@ -54,7 +54,7 @@ function docleanup($data)
         $count = count($users_buffer);
         if ($count > 0) {
             sql_query("INSERT INTO messages (sender,receiver,added,msg,subject) VALUES " . implode(', ', $msgs_buffer)) or sqlerr(__FILE__, __LINE__);
-            sql_query("INSERT INTO users (id, pirate, modcomment) VALUES " . implode(', ', $users_buffer) . " ON DUPLICATE key UPDATE pirate=values(pirate), modcomment=concat(values(modcomment),modcomment)") or sqlerr(__FILE__, __LINE__);
+            sql_query("INSERT INTO users (id, pirate, modcomment) VALUES " . implode(', ', $users_buffer) . " ON DUPLICATE key UPDATE pirate=values(pirate), modcomment=values(modcomment)") or sqlerr(__FILE__, __LINE__);
             write_log("Cleanup - Removed Pirate status from " . $count . " members");
         }
         unset($users_buffer, $msgs_buffer, $count);

--- a/include/cleanup/pu_demote_update.php
+++ b/include/cleanup/pu_demote_update.php
@@ -113,7 +113,7 @@ $prev_class_name = $arr2['classname'];
         $count = count($users_buffer);
         if ($count > 0) {
             sql_query("INSERT INTO messages (sender,receiver,added,msg,subject) VALUES " . implode(', ', $msgs_buffer)) or sqlerr(__FILE__, __LINE__);
-            sql_query("INSERT INTO users (id, class, modcomment) VALUES " . implode(', ', $users_buffer) . " ON DUPLICATE key UPDATE class=values(class),modcomment=concat(values(modcomment),modcomment)") or sqlerr(__FILE__, __LINE__);
+            sql_query("INSERT INTO users (id, class, modcomment) VALUES " . implode(', ', $users_buffer) . " ON DUPLICATE key UPDATE class=values(class),modcomment=values(modcomment)") or sqlerr(__FILE__, __LINE__);
             write_log("Cleanup: Demoted " . $count . " member(s) from $class_name to $prev_class_name");
             status_change($arr['id']);
         }

--- a/include/cleanup/pu_update.php
+++ b/include/cleanup/pu_update.php
@@ -122,7 +122,7 @@ $res = sql_query("SELECT id, uploaded, downloaded, invites, modcomment FROM user
         $count = count($users_buffer);
         if ($count > 0) {
             sql_query("INSERT INTO messages (sender,receiver,added,msg,subject) VALUES " . implode(', ', $msgs_buffer)) or sqlerr(__FILE__, __LINE__);
-            sql_query("INSERT INTO users (id, class, invites, modcomment) VALUES " . implode(', ', $users_buffer) . " ON DUPLICATE key UPDATE class=values(class), invites = invites+values(invites), modcomment=concat(values(modcomment),modcomment)") or sqlerr(__FILE__, __LINE__);
+            sql_query("INSERT INTO users (id, class, invites, modcomment) VALUES " . implode(', ', $users_buffer) . " ON DUPLICATE key UPDATE class=values(class), invites = invites+values(invites), modcomment=values(modcomment)") or sqlerr(__FILE__, __LINE__);
             write_log("Cleanup: Promoted " . $count . " member(s) from ".$prev_class_name." to ".$class_name."");
         }
         unset($users_buffer, $msgs_buffer, $update, $count);

--- a/include/cleanup/sendpmpos_update.php
+++ b/include/cleanup/sendpmpos_update.php
@@ -54,7 +54,7 @@ function docleanup($data)
         $count = count($users_buffer);
         if ($count > 0) {
             sql_query("INSERT INTO messages (sender,receiver,added,msg,subject) VALUES " . implode(', ', $msgs_buffer)) or sqlerr(__FILE__, __LINE__);
-            sql_query("INSERT INTO users (id, sendpmpos, modcomment) VALUES " . implode(', ', $users_buffer) . " ON DUPLICATE key UPDATE sendpmpos=values(sendpmpos), modcomment=concat(values(modcomment),modcomment)") or sqlerr(__FILE__, __LINE__);
+            sql_query("INSERT INTO users (id, sendpmpos, modcomment) VALUES " . implode(', ', $users_buffer) . " ON DUPLICATE key UPDATE sendpmpos=values(sendpmpos), modcomment=values(modcomment)") or sqlerr(__FILE__, __LINE__);
             write_log("Cleanup - Removed Pm ban from " . $count . " members");
         }
         unset($users_buffer, $msgs_buffer, $count);

--- a/include/cleanup/uploadpos_update.php
+++ b/include/cleanup/uploadpos_update.php
@@ -54,7 +54,7 @@ function docleanup($data)
         $count = count($users_buffer);
         if ($count > 0) {
             sql_query("INSERT INTO messages (sender,receiver,added,msg,subject) VALUES " . implode(', ', $msgs_buffer)) or sqlerr(__FILE__, __LINE__);
-            sql_query("INSERT INTO users (id, uploadpos, modcomment) VALUES " . implode(', ', $users_buffer) . " ON DUPLICATE key UPDATE uploadpos=values(uploadpos), modcomment=concat(values(modcomment),modcomment)") or sqlerr(__FILE__, __LINE__);
+            sql_query("INSERT INTO users (id, uploadpos, modcomment) VALUES " . implode(', ', $users_buffer) . " ON DUPLICATE key UPDATE uploadpos=values(uploadpos), modcomment=values(modcomment)") or sqlerr(__FILE__, __LINE__);
             write_log("Cleanup - Removed Upload ban from " . $count . " members");
         }
         unset($users_buffer, $msgs_buffer, $count);

--- a/include/cleanup/warned_update.php
+++ b/include/cleanup/warned_update.php
@@ -54,7 +54,7 @@ function docleanup($data)
         $count = count($users_buffer);
         if ($count > 0) {
             sql_query("INSERT INTO messages (sender,receiver,added,msg,subject) VALUES " . implode(', ', $msgs_buffer)) or sqlerr(__FILE__, __LINE__);
-            sql_query("INSERT INTO users (id, warned, modcomment) VALUES " . implode(', ', $users_buffer) . " ON DUPLICATE key UPDATE warned=values(warned), modcomment=concat(values(modcomment),modcomment)") or sqlerr(__FILE__, __LINE__);
+            sql_query("INSERT INTO users (id, warned, modcomment) VALUES " . implode(', ', $users_buffer) . " ON DUPLICATE key UPDATE warned=values(warned), modcomment=values(modcomment)") or sqlerr(__FILE__, __LINE__);
             write_log("Cleanup - Removed Warnings from " . $count . " members");
         }
         unset($users_buffer, $msgs_buffer, $count);


### PR DESCRIPTION
Since $modcom already contains the whole modcomment there shouldn't be a reason to concat them together and duplicate the whole modcomment
