### PR TITLE
Force to installer if no config file found

### DIFF
--- a/include/bittorrent.php
+++ b/include/bittorrent.php
@@ -18,6 +18,12 @@
  */
 //==Start execution time
 $start = microtime(true);
+
+if( !file_exists( dirname(__FILE__) . DIRECTORY_SEPARATOR . 'config.php' ) ) {
+    header('Location: /install');
+    die();
+}
+
 require_once (dirname(__FILE__) . DIRECTORY_SEPARATOR . 'config.php');
 require_once (CACHE_DIR . 'free_cache.php');
 require_once (CACHE_DIR . 'site_settings.php');


### PR DESCRIPTION
Redirect to installer page if no config file exists.

Currently - if you go to the index page is throws a 500 error - this gracefully pushes you to installer page.