### PR TITLE
remove pin call in system_view.php

### DIFF
--- a/admin/system_view.php
+++ b/admin/system_view.php
@@ -32,7 +32,7 @@ if (!defined('IN_INSTALLER09_ADMIN')) {
 }
 require_once (INCL_DIR . 'user_functions.php');
 require_once (CLASS_DIR . 'class_check.php');
-class_check(UC_MAX, true, true);
+class_check(UC_MAX, true);
 $lang = array_merge($lang, load_language('ad_systemview'));
 $htmlout = '';
 if (isset($_GET['phpinfo']) AND $_GET['phpinfo']) {


### PR DESCRIPTION
Having the '$pin' value set to 'true' results in a never-ending loop of auth calls. Idle on an auth call results in rejection.

the deeper issue appears to be a broken $pin function in class_check.php, but setting this to ignore the $pin results in equal security settings as found in $memcache, etc.
